### PR TITLE
Added the option for overriding the default watchdog observer.

### DIFF
--- a/hachiko/hachiko.py
+++ b/hachiko/hachiko.py
@@ -48,8 +48,12 @@ class AIOEventHandler(object):
 
 class AIOWatchdog(object):
 
-    def __init__(self, path='.', recursive=True, event_handler=None):
-        self._observer = Observer()
+    def __init__(self, path='.', recursive=True, event_handler=None,
+                 observer=None):
+        if observer is None:
+            self._observer = Observer()
+        else:
+            self._observer = observer
 
         evh = event_handler or AIOEventHandler()
 


### PR DESCRIPTION
This ability is useful when trying to watch over a mounted NFS,
in a linux machine, when the NFS is hosted on a windows machine, since
the default observer will use Inotify (watchdog assumes that it will be
the best polling method available on a linux machine) but Inotify syscall
won't work with the mounted NFS because it is hosted on windows.
In that case the user would want to override the default watchdog observer
with PollingObserver.

modified:   hachiko/hachiko.py

Signed-off-by: Eyal Royee <eyalroyee@gmail.com>