### PR TITLE
Support Python 3.8 - use async/await syntax instead of @asyncio.coroutine

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ You need to subclass AIOEventHandler and either:
 import asyncio
 from hachiko.hachiko import AIOWatchdog
 
-@asyncio.coroutine
-def watch_fs():
+async def watch_fs():
     watch = AIOWatchdog('/Users/jbiesnecker/temp/forks/test')
     watch.start()
     for _ in range(20):
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
     watch.stop()
 
 asyncio.get_event_loop().run_until_complete(watch_fs())

--- a/hachiko/hachiko.py
+++ b/hachiko/hachiko.py
@@ -18,20 +18,15 @@ class AIOEventHandler(object):
         else:
             self._ensure_future = asyncio.ensure_future
 
-    @asyncio.coroutine
-    def on_any_event(self, event): pass
+    async def on_any_event(self, event): pass
 
-    @asyncio.coroutine
-    def on_moved(self, event): pass
+    async def on_moved(self, event): pass
 
-    @asyncio.coroutine
-    def on_created(self, event): pass
+    async def on_created(self, event): pass
 
-    @asyncio.coroutine
-    def on_deleted(self, event): pass
+    async def on_deleted(self, event): pass
 
-    @asyncio.coroutine
-    def on_modified(self, event): pass
+    async def on_modified(self, event): pass
 
     def dispatch(self, event):
         _method_map = {

--- a/test.py
+++ b/test.py
@@ -1,12 +1,12 @@
 import asyncio
 from hachiko.hachiko import AIOWatchdog
 
-@asyncio.coroutine
-def watch_fs():
-    watch = AIOWatchdog('/Users/jbiesnecker/temp/forks/test')
+
+async def watch_fs():
+    watch = AIOWatchdog('/home/genevieve/Documents/Projects/watchdir/code/data/watch_dir/')
     watch.start()
     for _ in range(20):
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
     watch.stop()
 
 asyncio.get_event_loop().run_until_complete(watch_fs())


### PR DESCRIPTION
This PR provides support for Python 3.8

The `@asyncio.coroutine` syntax has been deprecated from Python 3.8. Switching to the async/await syntax doesn't cause any loss of functionality, now that the lowest version of python hachiko supports is Python 3.5 (PR https://github.com/biesnecker/hachiko/pull/6), which is when the async/await syntax [was first introduced](https://quietlyamused.org/blog/2015/10/02/async-python/).