### PR TITLE
Bugfix: handle 'closed' events

### DIFF
--- a/hachiko/hachiko.py
+++ b/hachiko/hachiko.py
@@ -5,6 +5,7 @@ EVENT_TYPE_MOVED = "moved"
 EVENT_TYPE_DELETED = "deleted"
 EVENT_TYPE_CREATED = "created"
 EVENT_TYPE_MODIFIED = "modified"
+EVENT_TYPE_CLOSED = "closed"
 
 
 class AIOEventHandler(object):
@@ -22,6 +23,7 @@ class AIOEventHandler(object):
             EVENT_TYPE_MOVED: self.on_moved,
             EVENT_TYPE_CREATED: self.on_created,
             EVENT_TYPE_DELETED: self.on_deleted,
+            EVENT_TYPE_CLOSED: self.on_closed,
         }
 
     async def on_any_event(self, event):
@@ -38,6 +40,10 @@ class AIOEventHandler(object):
 
     async def on_modified(self, event):
         pass
+
+    async def on_closed(self, event):
+        pass
+
 
     def dispatch(self, event):
         handler = self._method_map[event.event_type]


### PR DESCRIPTION
On some linux system, we can have a 'closed' event when the file is closed.
This commit handle this case.

Corresponding traceback:

Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/.../venv/lib/python3.7/site-packages/watchdog-2.0.2-py3.7.egg/watchdog/observers/api.py", line 199, in run
    self.dispatch_events(self.event_queue, self.timeout)
  File "/.../venv/lib/python3.7/site-packages/watchdog-2.0.2-py3.7.egg/watchdog/observers/api.py", line 372, in dispatch_events
    handler.dispatch(event)
  File "/.../venv/lib/python3.7/site-packages/hachiko/hachiko.py", line 43, in dispatch
    handler = self._method_map[event.event_type]
KeyError: 'closed'