### PR TITLE
Bugfix: handle 'opened' events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ class MyEventHandler(AIOEventHandler):
     async def on_modified(self, event):
         print('Modified:', event.src_path)  # add your functionality here
 
+    async def on_closed(self, event):
+        print('Closed:', event.src_path)  # add your functionality here
+
+    async def on_opened(self, event):
+        print('Opened:', event.src_path)  # add your functionality here
+
 
 async def watch_fs(watch_dir):
     evh = MyEventHandler()

--- a/example.py
+++ b/example.py
@@ -18,6 +18,12 @@ class MyEventHandler(AIOEventHandler):
     async def on_modified(self, event):
         print('Modified:', event.src_path)  # add your functionality here
 
+    async def on_closed(self, event):
+        print('Closed:', event.src_path)  # add your functionality here
+
+    async def on_opened(self, event):
+        print('Opened:', event.src_path)  # add your functionality here
+
 
 async def watch_fs(watch_dir):
     evh = MyEventHandler()

--- a/hachiko/hachiko.py
+++ b/hachiko/hachiko.py
@@ -6,6 +6,7 @@ EVENT_TYPE_DELETED = "deleted"
 EVENT_TYPE_CREATED = "created"
 EVENT_TYPE_MODIFIED = "modified"
 EVENT_TYPE_CLOSED = "closed"
+EVENT_TYPE_OPENED = "opened"
 
 
 class AIOEventHandler(object):
@@ -24,6 +25,7 @@ class AIOEventHandler(object):
             EVENT_TYPE_CREATED: self.on_created,
             EVENT_TYPE_DELETED: self.on_deleted,
             EVENT_TYPE_CLOSED: self.on_closed,
+            EVENT_TYPE_OPENED: self.on_opened,
         }
 
     async def on_any_event(self, event):
@@ -42,6 +44,9 @@ class AIOEventHandler(object):
         pass
 
     async def on_closed(self, event):
+        pass
+
+    async def on_opened(self, event):
         pass
 
 


### PR DESCRIPTION
On some linux system, we can have a 'opened' event when the file is opened.
This commit handle this case.

Corresponding traceback when running the tests:

/.../venv/lib/python3.11/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-1

Traceback (most recent call last):
File "/usr/lib64/python3.11/threading.py", line 1038, in _bootstrap_inner
  self.run()
File "/.../venv/lib/python3.11/site-packages/watchdog/observers/api.py", line 204, in run
  self.dispatch_events(self.event_queue)
File "/.../venv/lib/python3.11/site-packages/watchdog/observers/api.py", line 380, in dispatch_events
  handler.dispatch(event)
File "/.../venv/lib/python3.11/site-packages/hachiko/hachiko.py", line 49, in dispatch
  handler = self._method_map[event.event_type]
            ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'opened'