### PR TITLE
Fix observer positional argument + closed_no_write management

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ class MyEventHandler(AIOEventHandler):
     async def on_opened(self, event):
         print('Opened:', event.src_path)  # add your functionality here
 
+    async def on_closed_no_write(self, event):
+        print('Closed no write:', event.src_path)  # add your functionality here
 
 async def watch_fs(watch_dir):
     evh = MyEventHandler()

--- a/example.py
+++ b/example.py
@@ -24,6 +24,8 @@ class MyEventHandler(AIOEventHandler):
     async def on_opened(self, event):
         print('Opened:', event.src_path)  # add your functionality here
 
+    async def on_closed_no_write(self, event):
+        print('Closed no write:', event.src_path)  # add your functionality here
 
 async def watch_fs(watch_dir):
     evh = MyEventHandler()

--- a/hachiko/hachiko.py
+++ b/hachiko/hachiko.py
@@ -65,7 +65,7 @@ class AIOWatchdog(object):
 
         evh = event_handler or AIOEventHandler()
 
-        self._observer.schedule(evh, path, recursive)
+        self._observer.schedule(evh, path=path, recursive=recursive)
 
     def start(self):
         self._observer.start()

--- a/hachiko/hachiko.py
+++ b/hachiko/hachiko.py
@@ -7,7 +7,7 @@ EVENT_TYPE_CREATED = "created"
 EVENT_TYPE_MODIFIED = "modified"
 EVENT_TYPE_CLOSED = "closed"
 EVENT_TYPE_OPENED = "opened"
-
+EVENT_TYPE_CLOSED_NO_WRITE = "closed_no_write"
 
 class AIOEventHandler(object):
     """An asyncio-compatible event handler."""
@@ -26,6 +26,7 @@ class AIOEventHandler(object):
             EVENT_TYPE_DELETED: self.on_deleted,
             EVENT_TYPE_CLOSED: self.on_closed,
             EVENT_TYPE_OPENED: self.on_opened,
+            EVENT_TYPE_CLOSED_NO_WRITE: self.on_closed_no_write,
         }
 
     async def on_any_event(self, event):
@@ -49,6 +50,8 @@ class AIOEventHandler(object):
     async def on_opened(self, event):
         pass
 
+    async def on_closed_no_write(self, event):
+        pass
 
     def dispatch(self, event):
         handler = self._method_map[event.event_type]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-watchdog==5.0.2
+watchdog>=5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-watchdog
+watchdog==5.0.2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/biesnecker/hachiko",
     packages=["hachiko"],
     package_dir={"hachiko": "./hachiko"},
-    install_requires=["watchdog"],
+    install_requires=["watchdog>=5.0.0"],
     description="Asyncio wrapper around watchdog.",
     license="mit",
     long_description=read("README.txt"),


### PR DESCRIPTION
Fixing the `Observer.schedule()` problem with the latest version of watchdog (v5.0.2) and adding the support of the new `closed_no_write` event added with version [v5.0.0](https://github.com/gorakhargosh/watchdog/blob/master/changelog.rst#500).